### PR TITLE
Fix wrong stream server ca filename

### DIFF
--- a/www/nginx/src/opnsense/scripts/nginx/setup.php
+++ b/www/nginx/src/opnsense/scripts/nginx/setup.php
@@ -154,7 +154,7 @@ if (isset($nginx['stream_server'])) {
                     $ca = find_ca($caref);
                     if (isset($ca)) {
                         export_pem_file(
-                            KEY_DIRECTORY . $hostname . '_ca.pem',
+                            KEY_DIRECTORY . $stream_server['@attributes']['uuid'] . '_ca.pem',
                             $ca['crt']
                         );
                     }


### PR DESCRIPTION
If a CA Certificate for an stream server was selected the CA was saved with the last hostname set from the forearch loop of the HTTP Servers in the block above!